### PR TITLE
Update Tidy.pm

### DIFF
--- a/lib/CSS/Tidy.pm
+++ b/lib/CSS/Tidy.pm
@@ -78,6 +78,7 @@ sub tidy_css
     $text =~ s!(\{|\}|;)(\s*\S)!$1\n$2!g;
     $text =~ s!(\S\s*)(\})!$1\n$2!g;
     $text =~ s!(\S)(\{)!$1 $2!g;
+    $text =~ s!(\S*)(\})!$1\n$2!g;
 
     my @lines = split /\n/, $text;
 
@@ -111,7 +112,7 @@ sub tidy_css
 	    push @tidy, "$indent$after";
 	    next;
 	}
-	if (/\}/) {
+	while (/\}/g) {
 	    $depth--;
 	    if ($depth < 0) {
 		warn "$i: depth = $depth\n";


### PR DESCRIPTION
Both changes deal with closing curly brakets, that can give an ugly output.
The first change format the output CSS neat if there is more than one '}' on a single line. For example in heavy comprssed CSS:

@media (max-width: 596px){p{color:red;}}p{color:green;}

Together with the second change it writes a nice output.

The second sets the correct depth after more than one '}'. For example wth a media query:
```
@media (max-width: 596px) {
	p {
		color: red;
	}
}
	p {
		color: green;
	}
```
becomes:
```
@media (max-width: 596px) {
	p {
		color: red;
	}
}
p {
	color: green;
}
```